### PR TITLE
Configure EAS build

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,12 @@
 {
   "name": "GraduallyAdoptExpo",
-  "displayName": "GraduallyAdoptExpo"
+  "displayName": "GraduallyAdoptExpo",
+  "expo": {
+    "extra": {
+      "eas": {
+        "projectId": "94374dba-263e-45ae-a5b8-1670afc01865"
+      }
+    },
+    "owner": "keith-kurak"
+  }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,27 @@
+{
+  "cli": {
+    "version": ">= 12.3.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "development:simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/ios/GraduallyAdoptExpo.xcodeproj/project.pbxproj
+++ b/ios/GraduallyAdoptExpo.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -579,7 +579,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Why
- Repeatable builds for everyone, no configuration on your machine!
- Manages credentials for both ad hoc and store builds
- Auto-submits to the stores after a successful build

## How
Followed directions at: https://docs.expo.dev/build/introduction/

1. Ran `eas init` to setup project on EAS
2. Ran `eas build:configure` to setup build profiles in eas.json
3. Added `development:simulator` profile for iOS simulators, extending from `development` profile

## Test Plan
- [x] Ran development builds for iOS simulator / Android